### PR TITLE
fix: highlight tab.activeBorderTop

### DIFF
--- a/themes/lunar-color-theme.json
+++ b/themes/lunar-color-theme.json
@@ -2003,7 +2003,7 @@
     "tab.border": "#1a1b26",
     "tab.activeBackground": "#1a1b26",
     "tab.activeBorder": "#00000000",
-    "tab.activeBorderTop": "#00000000",
+    "tab.activeBorderTop": "#a5cdec",
     "tab.inactiveBackground": "#15161e",
     "tab.inactiveForeground": "#ffffff80",
     "scrollbarSlider.background": "#292e42",


### PR DESCRIPTION
Better to distinguish which tab I'm currently on even under sun light!

Before:
<img width="396" alt="Snipaste_2024-07-17_15-44-38" src="https://github.com/user-attachments/assets/bab1dcc5-0a68-4aa1-89c1-8b81a32bc55a">

After:
<img width="394" alt="Snipaste_2024-07-17_15-44-27" src="https://github.com/user-attachments/assets/4f281452-efa6-4893-8088-e1afd44615d2">

Uses the same color as the side bar:
<img width="47" alt="Snipaste_2024-07-17_15-44-55" src="https://github.com/user-attachments/assets/22364a8f-b5ba-4578-9505-c5b3ec1a82fb">
